### PR TITLE
Make FA thumbnails larger

### DIFF
--- a/bot/src/main/kotlin/me/ianmooreis/glyph/bot/Director.kt
+++ b/bot/src/main/kotlin/me/ianmooreis/glyph/bot/Director.kt
@@ -30,7 +30,9 @@ import kotlinx.coroutines.SupervisorJob
 import me.ianmooreis.glyph.bot.directors.config.ConfigDirector
 import me.ianmooreis.glyph.shared.config.server.ServerConfig
 import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
+import org.apache.commons.codec.digest.DigestUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import kotlin.coroutines.CoroutineContext
@@ -48,6 +50,12 @@ abstract class Director : ListenerAdapter(), CoroutineScope {
         get() = Dispatchers.Default + SupervisorJob()
 
     lateinit var configDirector: ConfigDirector
+
+    /**
+     * md5hex of the author id concatenated with the channel id to identify a context without being too revealing
+     */
+    protected val MessageReceivedEvent.contextHash: String
+        get() = DigestUtils.md5Hex(author.id + channel.id)
 
     protected val Guild.config: ServerConfig
         get(): ServerConfig = configDirector.getServerConfig(this)

--- a/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/MessagingDirector.kt
+++ b/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/MessagingDirector.kt
@@ -40,7 +40,6 @@ import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.events.message.MessageDeleteEvent
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-import org.apache.commons.codec.digest.DigestUtils
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
@@ -110,9 +109,8 @@ class MessagingDirector(
         val message: Message = event.message
 
         // Get ready to ask the DialogFlow agent
-        val sessionId = DigestUtils.md5Hex(event.author.id + event.channel.id)
         val ai = try {
-            aiAgent.request(event.message.contentClean, sessionId)
+            aiAgent.request(event.message.contentClean, event.contextHash)
         } catch (e: IllegalArgumentException) {
             message.addReaction("⁉").queue()
             return

--- a/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/QuickviewDirector.kt
+++ b/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/QuickviewDirector.kt
@@ -61,6 +61,11 @@ class QuickviewDirector(private val messagingDirector: MessagingDirector) : Dire
             withTimeout(generatorTimeout) {
                 generators.forEach {
                     it.generate(event, config.quickview).fold(event.messageId) { messageId, embed ->
+                        if (messageId == event.messageId) {
+                            event.message.suppressEmbeds(true).reason("Quickview").queue({}) {
+                                log.debug("Unable to suppress embeds for Quickviews in context ${event.contextHash}")
+                            }
+                        }
                         val responseId = event.channel.sendMessage(embed).await().id
                         messagingDirector.trackVolatile(messageId, responseId)
                         responseId

--- a/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/furaffinity/Submission.kt
+++ b/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/furaffinity/Submission.kt
@@ -135,7 +135,7 @@ data class Submission(
 
         return EmbedBuilder()
             .setTitle(title, link)
-            .setThumbnail(if (thumbnail) full else null)
+            .setImage(if (thumbnail) full else null)
             .setDescription(description.build())
             .addField("Keywords", fancyKeywords, false)
             .setFooter("FurAffinity")

--- a/shared/src/main/kotlin/me/ianmooreis/glyph/shared/config/server/ServerConfigsTable.kt
+++ b/shared/src/main/kotlin/me/ianmooreis/glyph/shared/config/server/ServerConfigsTable.kt
@@ -49,7 +49,7 @@ object ServerConfigsTable : Table() {
     val starboardThreshold: Column<Int> = integer("StarboardThreshold").default(1).check { it.greaterEq(1) }
     val starboardAllowSelfStar: Column<Boolean> = bool("StarboardAllowSelfStar").default(false)
     val quickviewFuraffinityEnabled: Column<Boolean> = bool("QuickviewFuraffinityEnabled").default(true)
-    val quickviewFuraffinityThumbnail: Column<Boolean> = bool("QuickviewFuraffinityThumbnail").default(true)
+    val quickviewFuraffinityThumbnail: Column<Boolean> = bool("QuickviewFuraffinityThumbnail").default(false)
     val quickviewPicartoEnabled: Column<Boolean> = bool("QuickviewPicartoEnabled").default(true)
     val wikiMinQuality: Column<Int> = integer("WikiMinQuality").default(50).check { it.between(0, 100) }
 }


### PR DESCRIPTION
By request FA thumbnails (where enabled) will now make a full size image instead of a small one in the Quickview embed. Furthermore, the bot will now suppress embeds on messages that trigger a Quickview to be created. This has the potential to hide wanted embeds, but that's likely a very rare occurrence.

I'm still not sure I like this being a feature of the bot, but some people seem to use it for this purpose. As for why it ever made it in, that's a long story about the origins of the bot and the community it was made for that I don't feel like explaining.